### PR TITLE
Remove help DMs

### DIFF
--- a/elsebot.py
+++ b/elsebot.py
@@ -27,7 +27,7 @@ if not isfile("database/config.json"):
 config = load(open("database/config.json", "r"))
 
 bot = commands.Bot(command_prefix=config['prefix'], description="elsebot, the elseplaces bot.",
-                   max_messages=10000, pm_help=True)
+                   max_messages=10000)
 
 
 @bot.event


### PR DESCRIPTION
I mean since the bot will take user messages from DMs, why the fuck would you send help information there?